### PR TITLE
Fixed delete tag bug on refresh

### DIFF
--- a/client/src/managers/tagManager.js
+++ b/client/src/managers/tagManager.js
@@ -44,8 +44,7 @@ export const createTag=(tag)=>{
       method: "DELETE",
       headers: {
         "Content-type": "application/json",
-      },
-      body: JSON.stringify(id),
+      }
     });
   };
 


### PR DESCRIPTION
- Updated deleteTag() fetch in `tagManger.js` by removing "body: JSON.stringify(id)," - delete function now working properly